### PR TITLE
Axe HTML Reporting Affected Elements Fix

### DIFF
--- a/utils/axe.py
+++ b/utils/axe.py
@@ -171,7 +171,7 @@ class Axe:
 
                     if 'nodes' in check:
                         for node in check['nodes']:
-                            section += f'''<tr><th class "details-header">Affected Node</th><td>{str(node).replace("<", "&lt;").replace(">", "&rt;")}</td></tr>'''
+                            section += f'''<tr><th class "details-header">Affected Node</th><td><code>{str(node).replace("<", "&lt;").replace(">", "&rt;")}</code></td></tr>'''
 
                     section += '</table><br />'
             else:

--- a/utils/axe.py
+++ b/utils/axe.py
@@ -165,10 +165,15 @@ class Axe:
                     section += f'''<table class="details-section"><tr><th>ID</th><td>{check["id"]}</td></tr>
                                 <tr><th class "details-header">Impact</th><td>{check["impact"]}</td></tr>
                                 <tr><th class "details-header">Tags</th><td>{check["tags"]}</td></tr>
-                                <tr><th class "details-header">Description</th><td>{str(check["description"]).replace("<", "").replace(">", "")}</td></tr>
-                                <tr><th class "details-header">Help</th><td>{str(check["help"]).replace("<", "").replace(">", "")}</td></tr>
-                                <tr><th class "details-header">Help URL</th><td><a href="{check["helpUrl"]}" target="_blank">{check["helpUrl"]}</a></td></tr>
-                                </table><br />'''
+                                <tr><th class "details-header">Description</th><td>{str(check["description"]).replace("<", "&lt;").replace(">", "&rt;")}</td></tr>
+                                <tr><th class "details-header">Help</th><td>{str(check["help"]).replace("<", "&lt;").replace(">", "&rt;")}</td></tr>
+                                <tr><th class "details-header">Help URL</th><td><a href="{check["helpUrl"]}" target="_blank">{check["helpUrl"]}</a></td></tr>'''
+
+                    if 'nodes' in check:
+                        for node in check['nodes']:
+                            section += f'''<tr><th class "details-header">Affected Node</th><td>{str(node).replace("<", "&lt;").replace(">", "&rt;")}</td></tr>'''
+
+                    section += '</table><br />'
             else:
                 section += f'<p>No {header} results returned.</p>'
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
This introduces a temporary fix for the Axe reporting class so it outputs the affected element in the HTML report.  It currently just outputs the JSON which isn't the nicest result but at least provides the information required to identify the issue.  A more permanent fix will be identified in due course.

## Context

<!-- Why is this change required? What problem does it solve? -->
At the moment the report highlights the errors, but not where the errors are.  This only impacts the HTML report.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
