### PR TITLE
Add docstring to HTML report

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,10 +6,15 @@ It is also used to define hooks that can be used to modify the behavior of pytes
 
 import pytest
 import os
+import typing
 from dotenv import load_dotenv
 from pathlib import Path
+from _pytest.python import Function
+from pytest_html.report_data import ReportData
 
-LOCAL_ENV_PATH = Path(os.getcwd()) / 'local.env'
+# Environment Variable Handling
+
+LOCAL_ENV_PATH = Path(os.getcwd()) / "local.env"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -24,3 +29,30 @@ def import_local_env_file() -> None:
     """
     if Path.is_file(LOCAL_ENV_PATH):
         load_dotenv(LOCAL_ENV_PATH, override=False)
+
+
+# HTML Report Customization
+
+
+def pytest_html_report_title(report: ReportData) -> None:
+    report.title = "Test Automation Report"
+
+
+def pytest_html_results_table_header(cells: list) -> None:
+    cells.insert(2, "<th>Description</th>")
+
+
+def pytest_html_results_table_row(report: object, cells: list) -> None:
+    description = getattr(report, "description", "N/A")
+    cells.insert(2, f"<td>{description}</td>")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: Function) -> typing.Generator[None, None, None]:
+    outcome = yield
+    if outcome is not None:
+        report = outcome.get_result()
+        report.description = str(item.function.__doc__)
+
+
+### Add your additional fixtures or hooks below ###


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
This adds the docstring from tests to the HTML report by default.

## Context

<!-- Why is this change required? What problem does it solve? -->
Makes it easier to understand exactly what a test is doing for non-technical stakehoders.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
